### PR TITLE
Use `voxel51` as organization

### DIFF
--- a/fiftyone.yaml
+++ b/fiftyone.yaml
@@ -1,4 +1,4 @@
-name: "@fiftyone/rerun-plugin"
+name: "@voxel51/rerun-plugin"
 description: Rerun plugin for FiftyOne
 version: 1.0.0
 fiftyone:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fiftyone/rerun-plugin",
+  "name": "@voxel51/rerun-plugin",
   "version": "1.0.0",
   "main": "src/index.tsx",
   "type": "module",


### PR DESCRIPTION
@sashankaryal can we use `@voxel51` as the organization name rather than `@fiftyone` for consistency with our other [Voxel51-authored plugins](https://github.com/voxel51/fiftyone-plugins?tab=readme-ov-file#core-plugins)?
